### PR TITLE
[asp-51]: feat: add module for gcs impl

### DIFF
--- a/pando/src/bin/test_gcs.rs
+++ b/pando/src/bin/test_gcs.rs
@@ -1,0 +1,6 @@
+use pando::storage;
+
+fn main() {
+    storage::gcs::upload_file();
+    storage::gcs::download_file();
+}

--- a/pando/src/lib.rs
+++ b/pando/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod models;
 pub mod schema;
+pub mod storage;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;

--- a/pando/src/storage.rs
+++ b/pando/src/storage.rs
@@ -1,0 +1,5 @@
+pub mod gcs;
+
+pub fn test() {
+    println!("test")
+}

--- a/pando/src/storage.rs
+++ b/pando/src/storage.rs
@@ -1,5 +1,1 @@
 pub mod gcs;
-
-pub fn test() {
-    println!("test")
-}

--- a/pando/src/storage/gcs.rs
+++ b/pando/src/storage/gcs.rs
@@ -1,0 +1,7 @@
+pub fn upload_file() {
+    println!("Uploading a file!")
+}
+
+pub fn download_file() {
+    println!("Downloading file")
+}


### PR DESCRIPTION
This PR creates the module structure for all the GCS code. 

This may be abstracted to a struct of state needs to be stored between calls, i.e. an API handler is created to save all the request logic. 