### PR TITLE
Asp 61 skeleton interface

### DIFF
--- a/pando/Cargo.toml
+++ b/pando/Cargo.toml
@@ -29,3 +29,4 @@ actix-web = "4"
 sanitize-filename = "0.4"
 uuid = { version = "1", features = ["v4"] }
 ipnetwork = "0.20.0"
+clap = { version = "4.0.22", features = ["derive"] }

--- a/pando/src/bin/main.rs
+++ b/pando/src/bin/main.rs
@@ -1,0 +1,46 @@
+use clap::{Parser, Subcommand};
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Host {
+        #[arg(short, long)]
+        host: bool,
+    },
+    Developer {
+        #[command(subcommand)]
+        command: Option<DeveloperCommands>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum DeveloperCommands {
+    Upload {
+        // #[arg(short, long)]
+        files: std::path::PathBuf,
+    },
+}
+fn main() {
+    let cli = Args::parse();
+
+    match &cli.command {
+        Some(Commands::Host { host }) => {
+            if *host {
+                println!("You are hosting something")
+            }
+        }
+        Some(Commands::Developer { command }) => match command {
+            Some(DeveloperCommands::Upload { files }) => {
+                println!("{}", files.to_str().expect("Not a valid Path"))
+            }
+            None => {
+                println!("No files provided!")
+            }
+        },
+        None => {}
+    }
+}

--- a/pando/src/bin/main.rs
+++ b/pando/src/bin/main.rs
@@ -8,8 +8,8 @@ struct Args {
 #[derive(Subcommand, Debug)]
 enum Commands {
     Host {
-        #[arg(short, long)]
-        host: bool,
+        #[command(subcommand)]
+        command: Option<HostCommands>,
     },
     Developer {
         #[command(subcommand)]
@@ -24,15 +24,22 @@ enum DeveloperCommands {
         files: std::path::PathBuf,
     },
 }
+#[derive(Subcommand, Debug)]
+enum HostCommands {
+    Start {},
+}
 fn main() {
     let cli = Args::parse();
 
     match &cli.command {
-        Some(Commands::Host { host }) => {
-            if *host {
-                println!("You are hosting something")
+        Some(Commands::Host { command }) => match command {
+            Some(HostCommands::Start {}) => {
+                println!("Starting the ASPN cloud")
             }
-        }
+            None => {
+                println!("No files provided!")
+            }
+        },
         Some(Commands::Developer { command }) => match command {
             Some(DeveloperCommands::Upload { files }) => {
                 println!("{}", files.to_str().expect("Not a valid Path"))

--- a/pando/src/bin/main.rs
+++ b/pando/src/bin/main.rs
@@ -7,6 +7,8 @@ struct Args {
 }
 #[derive(Subcommand, Debug)]
 enum Commands {
+    Init {},
+    Auth {},
     Host {
         #[command(subcommand)]
         command: Option<HostCommands>,
@@ -48,6 +50,9 @@ fn main() {
                 println!("No files provided!")
             }
         },
+        Some(_) => {
+            println!("Thanks for using the ASPN cloud")
+        }
         None => {}
     }
 }


### PR DESCRIPTION
This PR takes care of creating the boiler plate for using CLAP as a argument parser and creating sub commands. 

1. It creates subcommands for developers and hosts (to use the same CLI)
2. It adds boilerplate for auth and init commands. 

